### PR TITLE
Validate API base URL for frontend calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ This repository now ships with a Cloudflare Worker backend (see [`worker/`](work
 3. Initialize the database: `wrangler d1 execute HRIS_DB --file ./schema.sql`
 4. Start the worker: `npm run dev`
 
-The frontend expects the worker URL in the `VITE_API_BASE_URL` environment variable. Set it in `.env.local` before running `npm run dev`.
+The frontend expects the worker base URL (for example, `http://127.0.0.1:8787`) in the `VITE_API_BASE_URL` environment variable. Set it in `.env.local` before running `npm run dev`.

--- a/config/api.ts
+++ b/config/api.ts
@@ -1,1 +1,14 @@
-export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+const rawBaseUrl = import.meta.env.VITE_API_BASE_URL;
+
+export const API_BASE_URL = (() => {
+  if (!rawBaseUrl) {
+    console.warn('VITE_API_BASE_URL is not set; using relative API paths.');
+    return '';
+  }
+  try {
+    return new URL(rawBaseUrl).toString().replace(/\/$/, '');
+  } catch {
+    console.error('VITE_API_BASE_URL is invalid:', rawBaseUrl);
+    return '';
+  }
+})();

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -2,7 +2,8 @@ import { D1DatabaseSettings, R2StorageSettings } from '../types';
 import { API_BASE_URL } from '../config/api';
 
 const jsonFetch = async (path: string, options: RequestInit = {}) => {
-  const res = await fetch(`${API_BASE_URL}${path}`, {
+  const url = API_BASE_URL ? new URL(path, API_BASE_URL).toString() : path;
+  const res = await fetch(url, {
     headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
     ...options,
   });


### PR DESCRIPTION
## Summary
- validate `VITE_API_BASE_URL` and warn on missing/invalid values
- build API request URLs using the validated base
- document example `VITE_API_BASE_URL` value in README

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b46d3029e0832b825139177db11071