### PR TITLE
feat: add auth context and integrate

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React from 'react';
 import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 import Dashboard from './components/dashboard/Dashboard';
 import EmployeeManagement from './components/employees/EmployeeManagement';
@@ -9,74 +9,51 @@ import PayrollManagement from './components/payroll/PayrollManagement';
 import PerformanceManagement from './components/performance/PerformanceManagement';
 import SettingsManagement from './components/settings/SettingsManagement';
 import ReportManagement from './components/reports/ReportManagement';
-import { User } from './types';
-import { mockUsers } from './data/mockData';
 import LoginPage from './components/auth/LoginPage';
 import EmployeeDashboard from './components/dashboard/EmployeeDashboard';
 import MyProfile from './components/profile/MyProfile';
 import { ROLES } from './config/roles';
 import PayrollInfo from './components/payroll/PayrollInfo';
 import Layout from './components/layout/Layout';
+import { useAuth } from './context/AuthContext';
 
 const App: React.FC = () => {
-  const [loggedInUser, setLoggedInUser] = useState<User | null>(null);
-  const [loginError, setLoginError] = useState<string | null>(null);
+    const { user, login, loginError } = useAuth();
   const navigate = useNavigate();
 
   const handleLogin = (email: string, password: string) => {
-    const user = mockUsers.find(u => u.email.toLowerCase() === email.toLowerCase() && u.password === password);
-    if (user) {
-      setLoggedInUser(user);
-      setLoginError(null);
+    const success = login(email, password);
+    if (success) {
       navigate('/dashboard');
-    } else {
-      setLoginError("Email atau kata sandi salah.");
     }
   };
 
-  const handleLogout = () => {
-    setLoggedInUser(null);
-    navigate('/');
-  };
-
-  const handleUpdateUser = (updatedUser: User) => {
-    setLoggedInUser(updatedUser);
-    
-    // Also update the mock data source so changes persist during the session
-    const userIndex = mockUsers.findIndex(u => u.email === updatedUser.email);
-    if (userIndex > -1) {
-      mockUsers[userIndex] = { ...mockUsers[userIndex], ...updatedUser };
+    if (!user) {
+      return <LoginPage onLogin={handleLogin} loginError={loginError} />;
     }
-  };
 
-  if (!loggedInUser) {
-    return <LoginPage onLogin={handleLogin} loginError={loginError} />;
-  }
-
-  const isEmployee = loggedInUser.role === ROLES.PEGAWAI;
+  const isEmployee = user.role === ROLES.PEGAWAI;
 
   return (
-    <Routes>
-      <Route
-        element={<Layout user={loggedInUser} onUpdateUser={handleUpdateUser} onLogout={handleLogout} />}
-      >
-        <Route
-          path="/dashboard"
-          element={isEmployee ? <EmployeeDashboard user={loggedInUser!} /> : <Dashboard />}
-        />
-        <Route path="/employees" element={<EmployeeManagement />} />
-        <Route path="/attendance" element={<AttendanceManagement />} />
-        <Route path="/leave" element={<LeaveManagement user={loggedInUser!} />} />
-        <Route path="/payroll" element={<PayrollManagement />} />
-        <Route path="/performance" element={<PerformanceManagement />} />
-        <Route path="/reports" element={<ReportManagement />} />
-        <Route path="/settings" element={<SettingsManagement />} />
-        <Route path="/profile" element={<MyProfile user={loggedInUser!} />} />
-        <Route path="/payroll-info" element={<PayrollInfo user={loggedInUser!} />} />
-        <Route path="/" element={<Navigate to="/dashboard" replace />} />
-        <Route path="*" element={<Navigate to="/dashboard" replace />} />
-      </Route>
-    </Routes>
+      <Routes>
+        <Route element={<Layout />}>
+          <Route
+            path="/dashboard"
+            element={isEmployee ? <EmployeeDashboard /> : <Dashboard />}
+          />
+          <Route path="/employees" element={<EmployeeManagement />} />
+          <Route path="/attendance" element={<AttendanceManagement />} />
+          <Route path="/leave" element={<LeaveManagement />} />
+          <Route path="/payroll" element={<PayrollManagement />} />
+          <Route path="/performance" element={<PerformanceManagement />} />
+          <Route path="/reports" element={<ReportManagement />} />
+          <Route path="/settings" element={<SettingsManagement />} />
+          <Route path="/profile" element={<MyProfile />} />
+          <Route path="/payroll-info" element={<PayrollInfo />} />
+          <Route path="/" element={<Navigate to="/dashboard" replace />} />
+          <Route path="*" element={<Navigate to="/dashboard" replace />} />
+        </Route>
+      </Routes>
   );
 };
 

--- a/components/dashboard/EmployeeDashboard.tsx
+++ b/components/dashboard/EmployeeDashboard.tsx
@@ -4,13 +4,12 @@ import StatCard from './StatCard';
 import Card from '../shared/Card';
 import { mockAttendance, mockEmployees, mockLeaveRequests, mockLeaveTypes } from '../../data/mockData';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
-import { User, LeaveStatus } from '../../types';
+import { LeaveStatus } from '../../types';
+import { useAuth } from '../../context/AuthContext';
 
-interface EmployeeDashboardProps {
-    user: User;
-}
-
-const EmployeeDashboard: React.FC<EmployeeDashboardProps> = ({ user }) => {
+const EmployeeDashboard: React.FC = () => {
+    const { user } = useAuth();
+    if (!user) return null;
     const employee = useMemo(() => mockEmployees.find(e => e.email === user.email), [user.email]);
 
     const stats = useMemo(() => {

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,15 +1,13 @@
 
 import React, { useState, useEffect, useRef } from 'react';
-import { User } from '../../types';
 import UserProfileModal from '../user/UserProfileModal';
+import { useAuth } from '../../context/AuthContext';
+import { useNavigate } from 'react-router-dom';
 
-interface HeaderProps {
-    user: User;
-    onUpdateUser: (user: User) => void;
-    onLogout: () => void;
-}
-
-const Header: React.FC<HeaderProps> = ({ user, onUpdateUser, onLogout }) => {
+const Header: React.FC = () => {
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+  if (!user) return null;
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -71,7 +69,7 @@ const Header: React.FC<HeaderProps> = ({ user, onUpdateUser, onLogout }) => {
                     </a>
                     <a
                         href="#"
-                        onClick={(e) => { e.preventDefault(); onLogout(); }}
+                        onClick={(e) => { e.preventDefault(); logout(); navigate('/'); }}
                         className="block px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700"
                     >
                        <i className="fas fa-sign-out-alt w-5 mr-2"></i>Logout
@@ -82,12 +80,10 @@ const Header: React.FC<HeaderProps> = ({ user, onUpdateUser, onLogout }) => {
       </div>
     </header>
 
-    <UserProfileModal
-        isOpen={isProfileModalOpen}
-        onClose={() => setIsProfileModalOpen(false)}
-        user={user}
-        onUpdateUser={onUpdateUser}
-    />
+      <UserProfileModal
+          isOpen={isProfileModalOpen}
+          onClose={() => setIsProfileModalOpen(false)}
+      />
     </>
   );
 };

--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -3,19 +3,12 @@ import { Outlet } from 'react-router-dom';
 import Sidebar from './Sidebar';
 import Header from './Header';
 import Footer from './Footer';
-import { User } from '../../types';
 
-interface LayoutProps {
-  user: User;
-  onUpdateUser: (user: User) => void;
-  onLogout: () => void;
-}
-
-const Layout: React.FC<LayoutProps> = ({ user, onUpdateUser, onLogout }) => (
+const Layout: React.FC = () => (
   <div className="flex h-screen bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200">
-    <Sidebar user={user} />
+    <Sidebar />
     <div className="flex-1 flex flex-col overflow-hidden">
-      <Header user={user} onUpdateUser={onUpdateUser} onLogout={onLogout} />
+      <Header />
       <main className="flex-1 overflow-x-hidden overflow-y-auto bg-gray-100 dark:bg-gray-900 p-6">
         <Outlet />
       </main>

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -1,12 +1,9 @@
 
 import React from 'react';
 import { NavLink } from 'react-router-dom';
-import { View, User } from '../../types';
+import { View } from '../../types';
 import { rolePermissions } from '../../config/roles';
-
-interface SidebarProps {
-  user: User;
-}
+import { useAuth } from '../../context/AuthContext';
 
 interface NavItemProps {
   to: string;
@@ -32,7 +29,9 @@ const NavItem: React.FC<NavItemProps> = ({ to, label, icon }) => (
   </li>
 );
 
-const Sidebar: React.FC<SidebarProps> = ({ user }) => {
+const Sidebar: React.FC = () => {
+  const { user } = useAuth();
+  if (!user) return null;
   const availableViews = rolePermissions[user.role] || [];
 
   const navItems = [

--- a/components/leave/LeaveManagement.tsx
+++ b/components/leave/LeaveManagement.tsx
@@ -4,13 +4,14 @@ import React, { useState, useMemo, useEffect } from 'react';
 import Card from '../shared/Card';
 import Button from '../shared/Button';
 import { mockLeaveRequests, mockWahaSettings, mockEmployees } from '../../data/mockData';
-import { LeaveRequest, LeaveStatus, User } from '../../types';
+import { LeaveRequest, LeaveStatus } from '../../types';
 import Pagination from '../shared/Pagination';
 import ConfirmationModal from '../shared/ConfirmationModal';
 import { sendWhatsappMessage } from '../../services/notificationService';
 import AddLeaveRequestModal from './AddLeaveRequestModal';
 import LeaveRequestDetailModal from './LeaveRequestDetailModal';
 import { ROLES } from '../../config/roles';
+import { useAuth } from '../../context/AuthContext';
 
 const StatusBadge: React.FC<{ status: LeaveStatus }> = ({ status }) => {
     const statusClasses = {
@@ -25,11 +26,9 @@ const StatusBadge: React.FC<{ status: LeaveStatus }> = ({ status }) => {
     );
 };
 
-interface LeaveManagementProps {
-    user: User;
-}
-
-const LeaveManagement: React.FC<LeaveManagementProps> = ({ user }) => {
+const LeaveManagement: React.FC = () => {
+    const { user } = useAuth();
+    if (!user) return null;
     const isEmployeeView = user.role === ROLES.PEGAWAI;
     const currentEmployee = useMemo(() => mockEmployees.find(e => e.email === user.email), [user.email]);
 
@@ -258,7 +257,6 @@ const LeaveManagement: React.FC<LeaveManagementProps> = ({ user }) => {
                 isOpen={!!requestToView}
                 onClose={handleCloseDetailModal}
                 request={requestToView}
-                user={user}
                 onApprove={(req) => setActionToConfirm({ request: req, newStatus: LeaveStatus.APPROVED })}
                 onReject={(req) => setActionToConfirm({ request: req, newStatus: LeaveStatus.REJECTED })}
             />

--- a/components/leave/LeaveRequestDetailModal.tsx
+++ b/components/leave/LeaveRequestDetailModal.tsx
@@ -3,15 +3,15 @@
 import React from 'react';
 import Modal from '../shared/Modal';
 import Button from '../shared/Button';
-import { LeaveRequest, LeaveStatus, User } from '../../types';
+import { LeaveRequest, LeaveStatus } from '../../types';
 import { mockEmployees } from '../../data/mockData';
 import { ROLES } from '../../config/roles';
+import { useAuth } from '../../context/AuthContext';
 
 interface LeaveRequestDetailModalProps {
   isOpen: boolean;
   onClose: () => void;
   request: LeaveRequest | null;
-  user: User;
   onApprove: (request: LeaveRequest) => void;
   onReject: (request: LeaveRequest) => void;
 }
@@ -36,8 +36,9 @@ const StatusBadge: React.FC<{ status: LeaveStatus }> = ({ status }) => {
     );
 };
 
-const LeaveRequestDetailModal: React.FC<LeaveRequestDetailModalProps> = ({ isOpen, onClose, request, user, onApprove, onReject }) => {
-  if (!isOpen || !request) return null;
+const LeaveRequestDetailModal: React.FC<LeaveRequestDetailModalProps> = ({ isOpen, onClose, request, onApprove, onReject }) => {
+  const { user } = useAuth();
+  if (!isOpen || !request || !user) return null;
 
   const employee = mockEmployees.find(e => e.id === request.employeeId);
   const canTakeAction = user.role !== ROLES.PEGAWAI;

--- a/components/payroll/PayrollInfo.tsx
+++ b/components/payroll/PayrollInfo.tsx
@@ -4,15 +4,14 @@ import Card from '../shared/Card';
 import Button from '../shared/Button';
 import Modal from '../shared/Modal';
 import PayslipView from './PayslipView';
-import { User, Payslip, Employee } from '../../types';
+import { Payslip, Employee } from '../../types';
 import { mockEmployees, mockPayslips } from '../../data/mockData';
 import Pagination from '../shared/Pagination';
+import { useAuth } from '../../context/AuthContext';
 
-interface PayrollInfoProps {
-    user: User;
-}
-
-const PayrollInfo: React.FC<PayrollInfoProps> = ({ user }) => {
+const PayrollInfo: React.FC = () => {
+    const { user } = useAuth();
+    if (!user) return null;
     const [selectedPayslip, setSelectedPayslip] = useState<Payslip | null>(null);
     const [payslipToPrint, setPayslipToPrint] = useState<Payslip | null>(null);
     const [currentPage, setCurrentPage] = useState(1);

--- a/components/profile/MyProfile.tsx
+++ b/components/profile/MyProfile.tsx
@@ -1,12 +1,9 @@
 
 import React, { useMemo } from 'react';
 import Card from '../shared/Card';
-import { User, Employee, PositionHistory } from '../../types';
+import { Employee, PositionHistory } from '../../types';
 import { mockEmployees, mockPositionHistory } from '../../data/mockData';
-
-interface MyProfileProps {
-    user: User;
-}
+import { useAuth } from '../../context/AuthContext';
 
 const DetailRow: React.FC<{ label: string; value: React.ReactNode }> = ({ label, value }) => (
     <div className="grid grid-cols-3 gap-4 py-2 border-b border-gray-200 dark:border-gray-600 last:border-none">
@@ -15,7 +12,9 @@ const DetailRow: React.FC<{ label: string; value: React.ReactNode }> = ({ label,
     </div>
 );
 
-const MyProfile: React.FC<MyProfileProps> = ({ user }) => {
+const MyProfile: React.FC = () => {
+    const { user } = useAuth();
+    if (!user) return null;
     const employeeData: Employee | undefined = useMemo(() => {
         return mockEmployees.find(e => e.email.toLowerCase() === user.email.toLowerCase());
     }, [user.email]);

--- a/components/user/UserProfileModal.tsx
+++ b/components/user/UserProfileModal.tsx
@@ -2,17 +2,17 @@
 import React, { useState, useEffect } from 'react';
 import Modal from '../shared/Modal';
 import Button from '../shared/Button';
-import { User } from '../../types';
 import { mockUsers } from '../../data/mockData';
+import { useAuth } from '../../context/AuthContext';
 
 interface UserProfileModalProps {
   isOpen: boolean;
   onClose: () => void;
-  user: User;
-  onUpdateUser: (updatedUser: User) => void;
 }
 
-const UserProfileModal: React.FC<UserProfileModalProps> = ({ isOpen, onClose, user, onUpdateUser }) => {
+const UserProfileModal: React.FC<UserProfileModalProps> = ({ isOpen, onClose }) => {
+    const { user, updateUser } = useAuth();
+    if (!user) return null;
     const [activeTab, setActiveTab] = useState('profile');
     const [profileData, setProfileData] = useState({ name: '', email: '', whatsappNumber: '' });
     const [passwordData, setPasswordData] = useState({ currentPassword: '', newPassword: '', confirmPassword: '' });
@@ -57,7 +57,7 @@ const UserProfileModal: React.FC<UserProfileModalProps> = ({ isOpen, onClose, us
 
     const handleProfileSave = () => {
         if (validateProfile()) {
-            onUpdateUser({ ...user, ...profileData });
+              updateUser({ ...user, ...profileData });
             onClose();
         }
     };
@@ -102,7 +102,7 @@ const UserProfileModal: React.FC<UserProfileModalProps> = ({ isOpen, onClose, us
 
     const handleUpdateAvatar = () => {
         const newAvatarUrl = `https://picsum.photos/seed/${Date.now()}/100/100`;
-        onUpdateUser({ ...user, avatarUrl: newAvatarUrl });
+          updateUser({ ...user, avatarUrl: newAvatarUrl });
     };
 
     const TabButton: React.FC<{tabName: string, label: string}> = ({ tabName, label }) => (

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -1,0 +1,80 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { User } from '../types';
+import { mockUsers } from '../data/mockData';
+
+interface AuthContextType {
+  user: User | null;
+  token: string | null;
+  login: (email: string, password: string) => boolean;
+  logout: () => void;
+  updateUser: (user: User) => void;
+  loginError: string | null;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(() => {
+    const storedUser = localStorage.getItem('user');
+    return storedUser ? JSON.parse(storedUser) : null;
+  });
+  const [token, setToken] = useState<string | null>(() => localStorage.getItem('token'));
+  const [loginError, setLoginError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (user) {
+      localStorage.setItem('user', JSON.stringify(user));
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (token) {
+      localStorage.setItem('token', token);
+    }
+  }, [token]);
+
+  const login = (email: string, password: string) => {
+    const foundUser = mockUsers.find(
+      u => u.email.toLowerCase() === email.toLowerCase() && u.password === password
+    );
+    if (foundUser) {
+      setUser(foundUser);
+      setToken('mock-token');
+      setLoginError(null);
+      return true;
+    }
+    setLoginError('Email atau kata sandi salah.');
+    return false;
+  };
+
+  const logout = () => {
+    setUser(null);
+    setToken(null);
+    localStorage.removeItem('user');
+    localStorage.removeItem('token');
+  };
+
+  const updateUser = (updatedUser: User) => {
+    setUser(updatedUser);
+    const index = mockUsers.findIndex(u => u.email === updatedUser.email);
+    if (index > -1) {
+      mockUsers[index] = { ...mockUsers[index], ...updatedUser };
+    }
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, token, login, logout, updateUser, loginError }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export default AuthContext;

--- a/index.tsx
+++ b/index.tsx
@@ -1,19 +1,21 @@
-
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import { AuthProvider } from './context/AuthContext';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
-  throw new Error("Could not find root element to mount to");
+  throw new Error('Could not find root element to mount to');
 }
 
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
-  </React.StrictMode>
+  </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- add AuthContext for user/token state with localStorage persistence
- use AuthProvider in app and route components through context
- refactor user-dependent components to consume auth context

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Rollup failed to resolve import "react-router-dom")*

------
https://chatgpt.com/codex/tasks/task_e_68b473ac350c832b8095c4295482683d