### PR TITLE
feat: add error boundary and loading states

### DIFF
--- a/components/attendance/AttendanceManagement.tsx
+++ b/components/attendance/AttendanceManagement.tsx
@@ -9,8 +9,8 @@ import { useAttendanceRecords } from '../../hooks/useAttendance';
 import { useEmployees } from '../../hooks/useEmployees';
 
 const AttendanceManagement: React.FC = () => {
-    const { attendanceRecords, addRecord } = useAttendanceRecords();
-    const { employees } = useEmployees();
+    const { attendanceRecords, addRecord, loading: attendanceLoading, error: attendanceError } = useAttendanceRecords();
+    const { employees, loading: employeesLoading, error: employeesError } = useEmployees();
     const [isImportModalOpen, setIsImportModalOpen] = useState(false);
     // Default dates are set to October 2023 to ensure sample data is visible
     const [startDate, setStartDate] = useState('2023-10-01');
@@ -76,6 +76,22 @@ const AttendanceManagement: React.FC = () => {
         setIsImportModalOpen(false);
     };
 
+
+    if (attendanceLoading || employeesLoading) {
+        return (
+            <Card>
+                <p>Memuat data...</p>
+            </Card>
+        );
+    }
+
+    if (attendanceError || employeesError) {
+        return (
+            <Card>
+                <p className="text-red-500">Gagal memuat data presensi.</p>
+            </Card>
+        );
+    }
 
     return (
         <>

--- a/components/employees/EmployeeManagement.tsx
+++ b/components/employees/EmployeeManagement.tsx
@@ -11,7 +11,7 @@ import ConfirmationModal from '../shared/ConfirmationModal';
 import { useEmployees } from '../../hooks/useEmployees';
 
 const EmployeeManagement: React.FC = () => {
-    const { employees, positionHistory, addEmployee, updateEmployee, deleteEmployee } = useEmployees();
+    const { employees, positionHistory, addEmployee, updateEmployee, deleteEmployee, loading, error } = useEmployees();
     const [isAddModalOpen, setIsAddModalOpen] = useState(false);
     const [isImportModalOpen, setIsImportModalOpen] = useState(false);
     const [selectedEmployee, setSelectedEmployee] = useState<Employee | null>(null);
@@ -67,6 +67,22 @@ const EmployeeManagement: React.FC = () => {
         return filteredEmployees.slice(startIndex, startIndex + RECORDS_PER_PAGE);
     }, [filteredEmployees, currentPage]);
 
+
+    if (loading) {
+        return (
+            <Card>
+                <p>Memuat data pegawai...</p>
+            </Card>
+        );
+    }
+
+    if (error) {
+        return (
+            <Card>
+                <p className="text-red-500">Gagal memuat data pegawai.</p>
+            </Card>
+        );
+    }
 
     return (
         <Card>

--- a/components/leave/AddLeaveRequestModal.tsx
+++ b/components/leave/AddLeaveRequestModal.tsx
@@ -38,8 +38,24 @@ const AddLeaveRequestModal: React.FC<AddLeaveRequestModalProps> = ({ isOpen, onC
     const [leaveTypes, setLeaveTypes] = useState<LeaveType[]>([]);
     const [r2Enabled, setR2Enabled] = useState(false);
     const searchRef = useRef<HTMLDivElement>(null);
-    const { employees } = useEmployees();
-    const { leaveRequests } = useLeaveRequests();
+    const { employees, loading: employeesLoading, error: employeesError } = useEmployees();
+    const { leaveRequests, loading: leaveLoading, error: leaveError } = useLeaveRequests();
+
+    if (employeesLoading || leaveLoading) {
+        return (
+            <Modal isOpen={isOpen} onClose={onClose} title="Formulir Pengajuan Cuti / Izin">
+                <p>Memuat data...</p>
+            </Modal>
+        );
+    }
+
+    if (employeesError || leaveError) {
+        return (
+            <Modal isOpen={isOpen} onClose={onClose} title="Formulir Pengajuan Cuti / Izin">
+                <p className="text-red-500">Gagal memuat data.</p>
+            </Modal>
+        );
+    }
 
     const activeEmployees = useMemo(() => employees.filter(e => e.status === 'Active'), [employees]);
 

--- a/components/leave/LeaveManagement.tsx
+++ b/components/leave/LeaveManagement.tsx
@@ -30,9 +30,25 @@ const StatusBadge: React.FC<{ status: LeaveStatus }> = ({ status }) => {
 
 const LeaveManagement: React.FC = () => {
     const { user } = useAuth();
-    const { leaveRequests, addRequest, updateRequest } = useLeaveRequests();
-    const { employees } = useEmployees();
+    const { leaveRequests, addRequest, updateRequest, loading: leaveLoading, error: leaveError } = useLeaveRequests();
+    const { employees, loading: employeesLoading, error: employeesError } = useEmployees();
     if (!user) return null;
+
+    if (leaveLoading || employeesLoading) {
+        return (
+            <Card>
+                <p>Memuat data cuti...</p>
+            </Card>
+        );
+    }
+
+    if (leaveError || employeesError) {
+        return (
+            <Card>
+                <p className="text-red-500">Gagal memuat data cuti.</p>
+            </Card>
+        );
+    }
     const isEmployeeView = user.role === ROLES.PEGAWAI;
     const currentEmployee = useMemo(() => employees.find(e => e.email === user.email), [user.email, employees]);
 

--- a/components/leave/LeaveRequestDetailModal.tsx
+++ b/components/leave/LeaveRequestDetailModal.tsx
@@ -38,8 +38,24 @@ const StatusBadge: React.FC<{ status: LeaveStatus }> = ({ status }) => {
 
 const LeaveRequestDetailModal: React.FC<LeaveRequestDetailModalProps> = ({ isOpen, onClose, request, onApprove, onReject }) => {
   const { user } = useAuth();
-  const { employees } = useEmployees();
+  const { employees, loading, error } = useEmployees();
   if (!isOpen || !request || !user) return null;
+
+  if (loading) {
+    return (
+      <Modal isOpen={isOpen} onClose={onClose} title="Detail Pengajuan Cuti / Izin">
+        <p>Memuat data...</p>
+      </Modal>
+    );
+  }
+
+  if (error) {
+    return (
+      <Modal isOpen={isOpen} onClose={onClose} title="Detail Pengajuan Cuti / Izin">
+        <p className="text-red-500">Gagal memuat data pegawai.</p>
+      </Modal>
+    );
+  }
 
   const employee = employees.find(e => e.id === request.employeeId);
   const canTakeAction = user.role !== ROLES.PEGAWAI;

--- a/components/shared/ErrorBoundary.tsx
+++ b/components/shared/ErrorBoundary.tsx
@@ -1,0 +1,35 @@
+import React, { ErrorInfo } from 'react';
+import { logError } from '../../utils/logging';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  declare props: ErrorBoundaryProps;
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    logError(error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-4 text-red-500">Terjadi kesalahan yang tidak terduga.</div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/hooks/useAttendance.ts
+++ b/hooks/useAttendance.ts
@@ -6,18 +6,29 @@ import {
   updateAttendanceRecord as apiUpdateAttendanceRecord,
   deleteAttendanceRecord as apiDeleteAttendanceRecord,
 } from '../services/apiService';
+import { logError } from '../utils/logging';
 
 let attendanceCache: AttendanceRecord[] | null = null;
 
 export const useAttendanceRecords = () => {
   const [attendanceRecords, setAttendanceRecords] = useState<AttendanceRecord[]>(attendanceCache || []);
+  const [loading, setLoading] = useState(!attendanceCache);
+  const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
     if (!attendanceCache) {
-      fetchAttendanceRecords().then(data => {
-        attendanceCache = data;
-        setAttendanceRecords(data);
-      });
+      setLoading(true);
+      fetchAttendanceRecords()
+        .then(data => {
+          attendanceCache = data;
+          setAttendanceRecords(data);
+          setError(null);
+        })
+        .catch(err => {
+          setError(err);
+          logError(err);
+        })
+        .finally(() => setLoading(false));
     }
   }, []);
 
@@ -39,7 +50,7 @@ export const useAttendanceRecords = () => {
     setAttendanceRecords(attendanceCache);
   };
 
-  return { attendanceRecords, addRecord, updateRecord, deleteRecord };
+  return { attendanceRecords, addRecord, updateRecord, deleteRecord, loading, error };
 };
 
 export default useAttendanceRecords;

--- a/hooks/useLeaveRequests.ts
+++ b/hooks/useLeaveRequests.ts
@@ -6,18 +6,29 @@ import {
   updateLeaveRequest as apiUpdateLeaveRequest,
   deleteLeaveRequest as apiDeleteLeaveRequest,
 } from '../services/apiService';
+import { logError } from '../utils/logging';
 
 let leaveRequestsCache: LeaveRequest[] | null = null;
 
 export const useLeaveRequests = () => {
   const [leaveRequests, setLeaveRequests] = useState<LeaveRequest[]>(leaveRequestsCache || []);
+  const [loading, setLoading] = useState(!leaveRequestsCache);
+  const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
     if (!leaveRequestsCache) {
-      fetchLeaveRequests().then(data => {
-        leaveRequestsCache = data;
-        setLeaveRequests(data);
-      });
+      setLoading(true);
+      fetchLeaveRequests()
+        .then(data => {
+          leaveRequestsCache = data;
+          setLeaveRequests(data);
+          setError(null);
+        })
+        .catch(err => {
+          setError(err);
+          logError(err);
+        })
+        .finally(() => setLoading(false));
     }
   }, []);
 
@@ -43,7 +54,7 @@ export const useLeaveRequests = () => {
     setLeaveRequests(leaveRequestsCache);
   };
 
-  return { leaveRequests, addRequest, updateRequest, deleteRequest };
+  return { leaveRequests, addRequest, updateRequest, deleteRequest, loading, error };
 };
 
 export default useLeaveRequests;

--- a/index.tsx
+++ b/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import { AuthProvider } from './context/AuthContext';
+import ErrorBoundary from './components/shared/ErrorBoundary';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -12,10 +13,12 @@ if (!rootElement) {
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <AuthProvider>
-        <App />
-      </AuthProvider>
-    </BrowserRouter>
+    <ErrorBoundary>
+      <BrowserRouter>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </BrowserRouter>
+    </ErrorBoundary>
   </React.StrictMode>,
 );

--- a/utils/logging.ts
+++ b/utils/logging.ts
@@ -1,0 +1,7 @@
+export const logError = (error: unknown, info?: unknown) => {
+  if (typeof fetch === 'function') {
+    // Placeholder for sending error to monitoring endpoint
+    // fetch('/monitoring', { method: 'POST', body: JSON.stringify({ error, info }) }).catch(() => {});
+  }
+  console.error(error, info);
+};


### PR DESCRIPTION
## Summary
- add reusable ErrorBoundary with error logging
- wrap root app with ErrorBoundary
- expose loading and error states in data hooks and render placeholders
- add logging utility for future monitoring integrations

## Testing
- `npm run build` *(fails: Rollup failed to resolve import "react-router-dom" and 403 on installation)*
- `npx tsc --noEmit` *(fails: missing types for react-router-dom and other env-specific errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b479d41840832b87f267eab03a8e90