### PR TITLE
feat(worker): modular routing with validation

### DIFF
--- a/worker/package.json
+++ b/worker/package.json
@@ -5,6 +5,10 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy"
   },
+  "dependencies": {
+    "itty-router": "^4.0.23",
+    "zod": "^3.24.1"
+  },
   "devDependencies": {
     "wrangler": "^3.74.0"
   }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,10 +1,19 @@
-import { LeaveStatus } from '../../types';
+import { Router } from 'itty-router';
+import { z, ZodError } from 'zod';
+import { json } from './utils';
 import {
-  mockEmployees,
-  mockLeaveRequests,
-  mockPayslips,
-  mockUsers,
-} from '../../data/mockData';
+  getEmployees,
+  createEmployee,
+  updateEmployee,
+  deleteEmployee,
+} from './routes/employees';
+import {
+  getLeaveRequests,
+  createLeaveRequest,
+  updateLeaveStatus,
+} from './routes/leaveRequests';
+import { getPayslips, generatePayroll } from './routes/payroll';
+import { mockUsers } from '../../data/mockData';
 
 export interface Env {
   DB: D1Database;
@@ -12,173 +21,156 @@ export interface Env {
   PUBLIC_R2_URL: string;
 }
 
-const json = (data: unknown, init: ResponseInit = {}) =>
-  new Response(JSON.stringify(data), {
-    headers: { 'Content-Type': 'application/json' },
-    ...init,
-  });
+const router = Router();
+
+const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string(),
+});
+
+const d1SettingsSchema = z.object({
+  enabled: z.boolean(),
+  accountId: z.string(),
+  databaseId: z.string(),
+  authToken: z.string(),
+});
+
+const r2SettingsSchema = z.object({
+  enabled: z.boolean(),
+  accountId: z.string(),
+  bucketName: z.string(),
+  accessKeyId: z.string(),
+  secretAccessKey: z.string(),
+});
+
+const uploadUrlSchema = z.object({
+  fileName: z.string(),
+  contentType: z.string(),
+});
+
+router
+  // Employees
+  .get('/api/employees', getEmployees)
+  .post('/api/employees', createEmployee)
+  .put('/api/employees/:id', updateEmployee)
+  .delete('/api/employees/:id', deleteEmployee)
+
+  // Leave requests
+  .get('/api/leave-requests', getLeaveRequests)
+  .post('/api/leave-requests', createLeaveRequest)
+  .put('/api/leave-requests/:id/status', updateLeaveStatus)
+
+  // Payroll
+  .get('/api/payslips', getPayslips)
+  .post('/api/payroll/generate', generatePayroll)
+
+  // Authentication
+  .post('/api/login', async (request: Request) => {
+    const { email, password } = loginSchema.parse(await request.json());
+    const user = mockUsers.find((u) => u.email === email && u.password === password);
+    if (!user) {
+      return json({ success: false, message: 'Email atau kata sandi salah.' }, { status: 401 });
+    }
+    const { password: _pw, ...userData } = user;
+    return json({ success: true, user: userData });
+  })
+
+  // D1 settings
+  .get('/api/settings/database', async (_req: Request, env: Env) => {
+    const row = await env.DB.prepare('SELECT value FROM settings WHERE key = ?')
+      .bind('d1')
+      .first<{ value: string }>();
+    const settings = row
+      ? JSON.parse(row.value)
+      : { enabled: false, accountId: '', databaseId: '', authToken: '' };
+    delete settings.authToken;
+    return json(settings);
+  })
+  .post('/api/settings/database', async (request: Request, env: Env) => {
+    const data = d1SettingsSchema.parse(await request.json());
+    await env.DB.prepare('INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)')
+      .bind('d1', JSON.stringify(data))
+      .run();
+    return json({ message: 'Pengaturan berhasil disimpan.' });
+  })
+  .post('/api/settings/database/test', async (_req: Request, env: Env) => {
+    try {
+      await env.DB.prepare('SELECT 1').first();
+      return json({ success: true, message: 'Koneksi ke database berhasil.' });
+    } catch (e) {
+      return json({ success: false, message: 'Gagal terhubung ke database.' });
+    }
+  })
+
+  // Database seed
+  .post('/api/database/seed', () =>
+    json({ success: true, message: '\u2713 Data contoh berhasil disalin ke Cloudflare D1!' })
+  )
+
+  // R2 settings
+  .get('/api/settings/storage', async (_req: Request, env: Env) => {
+    const row = await env.DB.prepare('SELECT value FROM settings WHERE key = ?')
+      .bind('r2')
+      .first<{ value: string }>();
+    const settings = row
+      ? JSON.parse(row.value)
+      : {
+          enabled: false,
+          accountId: '',
+          bucketName: '',
+          accessKeyId: '',
+          secretAccessKey: '',
+        };
+    delete settings.accessKeyId;
+    delete settings.secretAccessKey;
+    return json(settings);
+  })
+  .post('/api/settings/storage', async (request: Request, env: Env) => {
+    const data = r2SettingsSchema.parse(await request.json());
+    await env.DB.prepare('INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)')
+      .bind('r2', JSON.stringify(data))
+      .run();
+    return json({ message: 'Pengaturan penyimpanan berhasil disimpan.' });
+  })
+  .post('/api/settings/storage/test', async (_req: Request, env: Env) => {
+    try {
+      await env.BUCKET.list({ limit: 1 });
+      return json({ success: true, message: 'Koneksi ke R2 Bucket berhasil.' });
+    } catch (e) {
+      return json({ success: false, message: 'Gagal terhubung ke R2 Bucket.' });
+    }
+  })
+
+  // R2 upload
+  .post('/api/storage/generate-upload-url', async (request: Request, env: Env) => {
+    const { fileName, contentType } = uploadUrlSchema.parse(await request.json());
+    const key = `${Date.now()}-${fileName}`;
+    const signed = await env.BUCKET.createPresignedUrl({
+      key,
+      method: 'PUT',
+      expiration: 300,
+      headers: { 'content-type': contentType },
+    });
+    const uploadUrl = signed.toString();
+    const finalUrl = `${env.PUBLIC_R2_URL}/${key}`;
+    return json({
+      success: true,
+      uploadUrl,
+      finalUrl,
+      message: 'URL berhasil dibuat.',
+    });
+  })
+
+  // 404 fallback
+  .all('*', () => new Response('Not found', { status: 404 }));
 
 export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-    const url = new URL(request.url);
-
-    try {
-      // Employees
-      if (url.pathname === '/api/employees') {
-        if (request.method === 'GET') {
-          return json(mockEmployees);
-        }
-        if (request.method === 'POST') {
-          const body = await request.json();
-          const newEmployee = { id: `E${Date.now()}`, ...body };
-          mockEmployees.push(newEmployee);
-          return json(newEmployee, { status: 201 });
-        }
+  fetch: (request: Request, env: Env, ctx: ExecutionContext) =>
+    router.handle(request, env, ctx).catch((err: unknown) => {
+      if (err instanceof ZodError) {
+        return json({ error: err.issues }, { status: 400 });
       }
-
-      if (url.pathname.startsWith('/api/employees/')) {
-        const id = url.pathname.split('/')[3];
-        const index = mockEmployees.findIndex((e) => e.id === id);
-        if (request.method === 'PUT') {
-          if (index === -1) return json({ message: 'Pegawai tidak ditemukan.' }, { status: 404 });
-          const body = await request.json();
-          mockEmployees[index] = { ...mockEmployees[index], ...body };
-          return json(mockEmployees[index]);
-        }
-        if (request.method === 'DELETE') {
-          if (index === -1) return json({ message: 'Pegawai tidak ditemukan.' }, { status: 404 });
-          mockEmployees.splice(index, 1);
-          return json({ message: 'Pegawai berhasil dihapus.' });
-        }
-      }
-
-      // Leave requests
-      if (url.pathname === '/api/leave-requests') {
-        if (request.method === 'GET') {
-          return json(mockLeaveRequests);
-        }
-        if (request.method === 'POST') {
-          const body = await request.json();
-          const newRequest = {
-            id: `L${Date.now()}`,
-            status: LeaveStatus.PENDING,
-            ...body,
-          };
-          mockLeaveRequests.push(newRequest);
-          return json(newRequest, { status: 201 });
-        }
-      }
-
-      if (url.pathname.startsWith('/api/leave-requests/') && url.pathname.endsWith('/status') && request.method === 'PUT') {
-        const parts = url.pathname.split('/');
-        const id = parts[3];
-        const body = await request.json();
-        const requestIndex = mockLeaveRequests.findIndex((r) => r.id === id);
-        if (requestIndex === -1) return json({ message: 'Permohonan tidak ditemukan.' }, { status: 404 });
-        mockLeaveRequests[requestIndex].status = body.status;
-        return json(mockLeaveRequests[requestIndex]);
-      }
-
-      // Payslips
-      if (url.pathname === '/api/payslips' && request.method === 'GET') {
-        const period = url.searchParams.get('period');
-        const list = period ? mockPayslips.filter((p) => p.period === period) : mockPayslips;
-        return json(list);
-      }
-
-      if (url.pathname === '/api/payroll/generate' && request.method === 'POST') {
-        return json({ success: true, message: 'Payroll berhasil dibuat.' });
-      }
-
-      // Authentication
-      if (url.pathname === '/api/login' && request.method === 'POST') {
-        const { email, password } = await request.json();
-        const user = mockUsers.find((u) => u.email === email && u.password === password);
-        if (!user) {
-          return json({ success: false, message: 'Email atau kata sandi salah.' }, { status: 401 });
-        }
-        const { password: _pw, ...userData } = user;
-        return json({ success: true, user: userData });
-      }
-
-      // D1 settings
-      if (url.pathname === '/api/settings/database') {
-        if (request.method === 'GET') {
-          const row = await env.DB.prepare('SELECT value FROM settings WHERE key = ?')
-            .bind('d1')
-            .first<{ value: string }>();
-          const settings = row ? JSON.parse(row.value) : { enabled: false, accountId: '', databaseId: '', authToken: '' };
-          delete settings.authToken;
-          return json(settings);
-        }
-        if (request.method === 'POST') {
-          const body = await request.json();
-          await env.DB.prepare('INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)')
-            .bind('d1', JSON.stringify(body))
-            .run();
-          return json({ message: 'Pengaturan berhasil disimpan.' });
-        }
-      }
-
-      if (url.pathname === '/api/settings/database/test' && request.method === 'POST') {
-        try {
-          await env.DB.prepare('SELECT 1').first();
-          return json({ success: true, message: 'Koneksi ke database berhasil.' });
-        } catch (e) {
-          return json({ success: false, message: 'Gagal terhubung ke database.' });
-        }
-      }
-
-      if (url.pathname === '/api/database/seed' && request.method === 'POST') {
-        return json({ success: true, message: '\u2713 Data contoh berhasil disalin ke Cloudflare D1!' });
-      }
-
-      // R2 settings
-      if (url.pathname === '/api/settings/storage') {
-        if (request.method === 'GET') {
-          const row = await env.DB.prepare('SELECT value FROM settings WHERE key = ?')
-            .bind('r2')
-            .first<{ value: string }>();
-          const settings = row ? JSON.parse(row.value) : { enabled: false, accountId: '', bucketName: '', accessKeyId: '', secretAccessKey: '' };
-          delete settings.accessKeyId;
-          delete settings.secretAccessKey;
-          return json(settings);
-        }
-        if (request.method === 'POST') {
-          const body = await request.json();
-          await env.DB.prepare('INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)')
-            .bind('r2', JSON.stringify(body))
-            .run();
-          return json({ message: 'Pengaturan penyimpanan berhasil disimpan.' });
-        }
-      }
-
-      if (url.pathname === '/api/settings/storage/test' && request.method === 'POST') {
-        try {
-          await env.BUCKET.list({ limit: 1 });
-          return json({ success: true, message: 'Koneksi ke R2 Bucket berhasil.' });
-        } catch (e) {
-          return json({ success: false, message: 'Gagal terhubung ke R2 Bucket.' });
-        }
-      }
-
-      if (url.pathname === '/api/storage/generate-upload-url' && request.method === 'POST') {
-        const { fileName, contentType } = await request.json();
-        const key = `${Date.now()}-${fileName}`;
-        const signed = await env.BUCKET.createPresignedUrl({
-          key,
-          method: 'PUT',
-          expiration: 300,
-          headers: { 'content-type': contentType },
-        });
-        const uploadUrl = signed.toString();
-        const finalUrl = `${env.PUBLIC_R2_URL}/${key}`;
-        return json({ success: true, uploadUrl, finalUrl, message: 'URL berhasil dibuat.' });
-      }
-
-      return new Response('Not found', { status: 404 });
-    } catch (err: any) {
-      return json({ error: err.message || 'Internal error' }, { status: 500 });
-    }
-  },
+      const message = err instanceof Error ? err.message : 'Internal error';
+      return json({ error: message }, { status: 500 });
+    }),
 };

--- a/worker/src/routes/employees.ts
+++ b/worker/src/routes/employees.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+import type { IRequest } from 'itty-router';
+import { mockEmployees } from '../../../data/mockData';
+import { json } from '../utils';
+
+const employeeSchema = z.object({
+  name: z.string(),
+  nip: z.string(),
+  position: z.string(),
+  unit: z.string(),
+  email: z.string().email(),
+  whatsappNumber: z.string(),
+  status: z.string(),
+  avatarUrl: z.string().optional(),
+  joinDate: z.string(),
+  bankName: z.string().optional(),
+  accountNumber: z.string().optional(),
+});
+
+export const getEmployees = () => json(mockEmployees);
+
+export const createEmployee = async (request: IRequest) => {
+  const data = employeeSchema.parse(await request.json());
+  const newEmployee = { id: `E${Date.now()}`, ...data };
+  mockEmployees.push(newEmployee);
+  return json(newEmployee, { status: 201 });
+};
+
+export const updateEmployee = async (request: IRequest) => {
+  const id = request.params?.id;
+  const index = mockEmployees.findIndex((e) => e.id === id);
+  if (index === -1) {
+    return json({ message: 'Pegawai tidak ditemukan.' }, { status: 404 });
+  }
+  const data = employeeSchema.partial().parse(await request.json());
+  mockEmployees[index] = { ...mockEmployees[index], ...data };
+  return json(mockEmployees[index]);
+};
+
+export const deleteEmployee = (request: IRequest) => {
+  const id = request.params?.id;
+  const index = mockEmployees.findIndex((e) => e.id === id);
+  if (index === -1) {
+    return json({ message: 'Pegawai tidak ditemukan.' }, { status: 404 });
+  }
+  mockEmployees.splice(index, 1);
+  return json({ message: 'Pegawai berhasil dihapus.' });
+};

--- a/worker/src/routes/leaveRequests.ts
+++ b/worker/src/routes/leaveRequests.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+import type { IRequest } from 'itty-router';
+import { LeaveStatus } from '../../../types';
+import { mockLeaveRequests } from '../../../data/mockData';
+import { json } from '../utils';
+
+const leaveRequestSchema = z.object({
+  employeeId: z.string(),
+  employeeName: z.string(),
+  leaveType: z.string(),
+  startDate: z.string(),
+  endDate: z.string(),
+  reason: z.string(),
+  documentName: z.string().optional(),
+});
+
+const statusSchema = z.object({
+  status: z.nativeEnum(LeaveStatus),
+});
+
+export const getLeaveRequests = () => json(mockLeaveRequests);
+
+export const createLeaveRequest = async (request: IRequest) => {
+  const data = leaveRequestSchema.parse(await request.json());
+  const newRequest = {
+    id: `L${Date.now()}`,
+    status: LeaveStatus.PENDING,
+    ...data,
+  };
+  mockLeaveRequests.push(newRequest);
+  return json(newRequest, { status: 201 });
+};
+
+export const updateLeaveStatus = async (request: IRequest) => {
+  const id = request.params?.id;
+  const index = mockLeaveRequests.findIndex((r) => r.id === id);
+  if (index === -1) {
+    return json({ message: 'Permohonan tidak ditemukan.' }, { status: 404 });
+  }
+  const data = statusSchema.parse(await request.json());
+  mockLeaveRequests[index].status = data.status;
+  return json(mockLeaveRequests[index]);
+};

--- a/worker/src/routes/payroll.ts
+++ b/worker/src/routes/payroll.ts
@@ -1,0 +1,14 @@
+import type { IRequest } from 'itty-router';
+import { mockPayslips } from '../../../data/mockData';
+import { json } from '../utils';
+
+export const getPayslips = (request: IRequest) => {
+  const period = new URL(request.url).searchParams.get('period');
+  const list = period
+    ? mockPayslips.filter((p) => p.period === period)
+    : mockPayslips;
+  return json(list);
+};
+
+export const generatePayroll = () =>
+  json({ success: true, message: 'Payroll berhasil dibuat.' });

--- a/worker/src/utils.ts
+++ b/worker/src/utils.ts
@@ -1,0 +1,5 @@
+export const json = (data: unknown, init: ResponseInit = {}) =>
+  new Response(JSON.stringify(data), {
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });


### PR DESCRIPTION
## Summary
- add itty-router and zod dependencies for worker
- modularize employee, leave request, and payroll routes with schema validation
- route requests through itty-router and validate payloads before DB/R2 operations

## Testing
- `npm --prefix worker test` *(fails: Missing script "test")*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b47b7d0184832b8436d649e22bd29d