### PR TITLE
test: add vitest setup and component tests

### DIFF
--- a/components/employees/__tests__/EmployeeManagement.test.tsx
+++ b/components/employees/__tests__/EmployeeManagement.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, vi, expect } from 'vitest';
+import EmployeeManagement from '../EmployeeManagement';
+
+vi.mock('../../../hooks/useEmployees', () => ({
+  useEmployees: () => ({
+    employees: [
+      {
+        id: 'E001',
+        name: 'John Doe',
+        nip: '123',
+        position: 'Manager',
+        unit: 'HR',
+        email: 'john@example.com',
+        whatsappNumber: '0812345678',
+        status: 'Active',
+        joinDate: '2020-01-01',
+        avatarUrl: '',
+      },
+    ],
+    positionHistory: [],
+    addEmployee: vi.fn(),
+    updateEmployee: vi.fn(),
+    deleteEmployee: vi.fn(),
+    loading: false,
+    error: null,
+  }),
+}));
+
+describe('EmployeeManagement', () => {
+  it('displays employee data', () => {
+    render(<EmployeeManagement />);
+    expect(screen.getByText('Pengelolaan Pegawai')).toBeInTheDocument();
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+  });
+});

--- a/components/shared/__tests__/Button.test.tsx
+++ b/components/shared/__tests__/Button.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import Button from '../Button';
+import { describe, it, expect } from 'vitest';
+
+describe('Button', () => {
+  it('renders children text', () => {
+    render(<Button>Click me</Button>);
+    expect(screen.getByRole('button')).toHaveTextContent('Click me');
+  });
+
+  it('applies secondary variant class', () => {
+    render(<Button variant="secondary">Secondary</Button>);
+    expect(screen.getByRole('button').className).toContain('bg-gray-200');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^19.1.1",
@@ -22,6 +23,10 @@
     "@types/node": "^22.14.0",
     "@types/xlsx": "^0.17.12",
     "typescript": "~5.8.2",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vitest": "^1.6.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.4.2",
+    "jsdom": "^24.0.0"
   }
 }

--- a/services/__tests__/apiService.test.ts
+++ b/services/__tests__/apiService.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getD1Settings } from '../apiService';
+
+describe('apiService', () => {
+  it('fetches D1 settings from worker endpoint', async () => {
+    const mockResponse = { enabled: true, accountId: 'acc', databaseId: 'db', authToken: 'token' };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    }) as any;
+
+    const data = await getD1Settings();
+    expect(global.fetch).toHaveBeenCalledWith('/api/settings/database', {
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(data).toEqual(mockResponse);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from 'path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.ts',
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- configure Vitest with jsdom environment
- add tests for Button and EmployeeManagement components
- cover API service fetch call with mocked Worker endpoint

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b47d6e4ba0832b81f43997ed264388