### PR TITLE
feat: expose worker config status

### DIFF
--- a/PANDUAN_CLOUDFLARE.md
+++ b/PANDUAN_CLOUDFLARE.md
@@ -175,3 +175,16 @@ CREATE TABLE leave_requests (
 ```
 
 Dengan mengikuti panduan ini, Anda telah berhasil mengkonfigurasi infrastruktur cloud yang diperlukan untuk menjalankan aplikasi HRIS UNUGHA dengan data yang persisten dan aman.
+
+## Bagian 4: Menyuntikkan Konfigurasi ke Lingkungan Produksi
+
+Gunakan variabel lingkungan pada Cloudflare Worker untuk menyimpan konfigurasi tanpa mengungkapkan nilai rahasia ke klien.
+
+1. Masukkan nilai non-sensitif seperti `WAHA_ENDPOINT` dan `WAHA_SESSION_NAME` pada bagian `[vars]` di `wrangler.toml`.
+2. Simpan nilai rahasia seperti token API menggunakan perintah Wrangler:
+
+   ```bash
+   wrangler secret put WAHA_API_KEY
+   ```
+
+3. Worker menyediakan endpoint `GET /api/config/status` untuk memeriksa apakah konfigurasi telah diisi tanpa menampilkan nilai rahasia.

--- a/README.md
+++ b/README.md
@@ -29,3 +29,17 @@ This repository now ships with a Cloudflare Worker backend (see [`worker/`](work
 4. Start the worker: `npm run dev`
 
 The frontend expects the worker base URL (for example, `http://127.0.0.1:8787`) in the `VITE_API_BASE_URL` environment variable. Set it in `.env.local` before running `npm run dev`.
+
+## Production configuration
+
+Configure environment values for the worker without exposing secrets to the client.
+
+1. Add non-sensitive variables such as `WAHA_ENDPOINT` and `WAHA_SESSION_NAME` in `worker/wrangler.toml` under `[vars]`.
+2. Store sensitive tokens using Wrangler secrets:
+
+   ```bash
+   cd worker
+   wrangler secret put WAHA_API_KEY
+   ```
+
+3. The worker exposes `GET /api/config/status` to verify that configuration values exist without revealing them.

--- a/components/settings/SettingsManagement.tsx
+++ b/components/settings/SettingsManagement.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Card from '../shared/Card';
 import Button from '../shared/Button';
 import { MasterDataView } from '../../types';
@@ -11,6 +11,8 @@ import WhatsappNotificationManagement from './WhatsappNotificationManagement';
 import PartnerBankManagement from './PartnerBankManagement';
 import DatabaseSettingsManagement from './DatabaseSettingsManagement';
 import R2StorageManagement from './R2StorageManagement';
+import { getWorkerConfigStatus } from '../../services/apiService';
+import { WorkerConfigStatus } from '../../types';
 
 
 interface MasterDataCardProps {
@@ -37,6 +39,11 @@ const MasterDataCard: React.FC<MasterDataCardProps> = ({ title, description, ico
 
 const SettingsManagement: React.FC = () => {
     const [currentView, setCurrentView] = useState<MasterDataView>(MasterDataView.NONE);
+    const [configStatus, setConfigStatus] = useState<WorkerConfigStatus | null>(null);
+
+    useEffect(() => {
+        getWorkerConfigStatus().then(setConfigStatus).catch(() => setConfigStatus(null));
+    }, []);
 
     const renderView = () => {
         switch(currentView) {
@@ -64,6 +71,11 @@ const SettingsManagement: React.FC = () => {
     const renderOverview = () => (
         <div>
             <h2 className="text-2xl font-bold mb-4">Pengaturan Master Data & Integrasi</h2>
+            {configStatus && (
+                <div className="mb-4 p-4 bg-gray-100 dark:bg-gray-700 rounded-md text-sm">
+                    <p>API Key WAHA terpasang: {configStatus.waha.hasApiKey ? 'Ya' : 'Tidak'}</p>
+                </div>
+            )}
             <p className="mb-6 text-gray-600 dark:text-gray-400">
                 Kelola data pokok yang digunakan di seluruh sistem HRIS dan konfigurasikan integrasi dengan layanan eksternal.
             </p>

--- a/components/settings/WhatsappNotificationManagement.tsx
+++ b/components/settings/WhatsappNotificationManagement.tsx
@@ -117,7 +117,6 @@ const WhatsappNotificationManagement: React.FC = () => {
                      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                         <FormField name="endpoint" label="WAHA Endpoint URL" />
                         <FormField name="sessionName" label="Nama Sesi (Session Name)" />
-                        <FormField name="apiKey" label="API Key (Opsional)" placeholder="Kosongkan jika tidak ada" />
                      </div>
                 </div>
 

--- a/data/mockData.ts
+++ b/data/mockData.ts
@@ -145,7 +145,6 @@ export const mockWahaSettings: WahaSettings = {
     enabled: true,
     endpoint: 'http://localhost:3000',
     sessionName: 'default',
-    apiKey: '',
     triggers: {
         leaveApproved: true,
         leaveRejected: true,

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -1,4 +1,4 @@
-import { D1DatabaseSettings, R2StorageSettings } from '../types';
+import { D1DatabaseSettings, R2StorageSettings, WorkerConfigStatus } from '../types';
 import { API_BASE_URL } from '../config/api';
 import {
   mockEmployees,
@@ -71,6 +71,10 @@ export const generatePresignedUrl = async (
     method: 'POST',
     body: JSON.stringify({ fileName, contentType }),
   });
+};
+
+export const getWorkerConfigStatus = async (): Promise<WorkerConfigStatus> => {
+  return jsonFetch('/api/config/status');
 };
 
 export const uploadFileWithPresignedUrl = async (

--- a/services/notificationService.ts
+++ b/services/notificationService.ts
@@ -50,9 +50,6 @@ export const sendWhatsappMessage = async (
   const headers: HeadersInit = {
     'Content-Type': 'application/json',
   };
-  if (settings.apiKey) {
-    headers['X-Api-Key'] = settings.apiKey;
-  }
 
   const body = JSON.stringify({
     chatId: `${recipient}@c.us`,

--- a/types.ts
+++ b/types.ts
@@ -167,8 +167,15 @@ export interface WahaSettings {
   enabled: boolean;
   endpoint: string;
   sessionName: string;
-  apiKey?: string;
   triggers: WahaTriggers;
+}
+
+export interface WorkerConfigStatus {
+  waha: {
+    endpoint: boolean;
+    sessionName: boolean;
+    hasApiKey: boolean;
+  };
 }
 
 export interface PartnerBank {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -19,6 +19,9 @@ export interface Env {
   DB: D1Database;
   BUCKET: R2Bucket;
   PUBLIC_R2_URL: string;
+  WAHA_ENDPOINT: string;
+  WAHA_SESSION_NAME: string;
+  WAHA_API_KEY: string;
 }
 
 const router = Router();
@@ -74,6 +77,17 @@ router
     const { password: _pw, ...userData } = user;
     return json({ success: true, user: userData });
   })
+
+  // Worker config status
+  .get('/api/config/status', (_req: Request, env: Env) =>
+    json({
+      waha: {
+        endpoint: Boolean(env.WAHA_ENDPOINT),
+        sessionName: Boolean(env.WAHA_SESSION_NAME),
+        hasApiKey: Boolean(env.WAHA_API_KEY),
+      },
+    })
+  )
 
   // D1 settings
   .get('/api/settings/database', async (_req: Request, env: Env) => {

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -13,3 +13,5 @@ bucket_name = "hris-bucket"
 
 [vars]
 PUBLIC_R2_URL = "https://example.r2.dev/your-bucket"
+WAHA_ENDPOINT = "https://waha.example.com"
+WAHA_SESSION_NAME = "default"


### PR DESCRIPTION
## Summary
- keep WhatsApp gateway token server-side and drop API key fields from client
- add worker endpoint to report config status without secrets and surface it in settings UI
- document how to inject production configuration via worker environment variables and secrets

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - @hookform/resolvers)*

------
https://chatgpt.com/codex/tasks/task_e_68b47e825ca8832babb5c0d939d32891