### PR TITLE
feat: add i18n support with language switcher

### DIFF
--- a/components/auth/LoginPage.tsx
+++ b/components/auth/LoginPage.tsx
@@ -3,6 +3,7 @@ import Button from '../shared/Button';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { loginSchema, LoginFormData } from './schema';
+import { useTranslation } from 'react-i18next';
 
 interface LoginPageProps {
   onLogin: (email: string, password: string) => void;
@@ -10,6 +11,7 @@ interface LoginPageProps {
 }
 
 const LoginPage: React.FC<LoginPageProps> = ({ onLogin, loginError }) => {
+  const { t } = useTranslation();
   const {
     register,
     handleSubmit,
@@ -33,7 +35,7 @@ const LoginPage: React.FC<LoginPageProps> = ({ onLogin, loginError }) => {
             <i className="fas fa-university fa-3x text-blue-600"></i>
             <h1 className="text-3xl font-bold ml-4 text-gray-800 dark:text-white">HRIS UNUGHA</h1>
           </div>
-          <h2 className="text-xl text-gray-600 dark:text-gray-300">Selamat Datang Kembali</h2>
+          <h2 className="text-xl text-gray-600 dark:text-gray-300">{t('welcomeBack')}</h2>
         </div>
         <form className="mt-8 space-y-6" onSubmit={handleSubmit(onSubmit)} noValidate>
           {loginError && (
@@ -46,28 +48,28 @@ const LoginPage: React.FC<LoginPageProps> = ({ onLogin, loginError }) => {
           )}
           <div className="rounded-md shadow-sm -space-y-px">
             <div>
-              <label htmlFor="email-address" className="sr-only">Alamat Email</label>
+              <label htmlFor="email-address" className="sr-only">{t('email')}</label>
               <input
                 id="email-address"
                 type="email"
                 autoComplete="email"
                 {...register('email')}
                 className={`appearance-none rounded-none relative block w-full px-3 py-2 border placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white ${errors.email ? 'border-red-500' : 'border-gray-300'}`}
-                placeholder="Alamat Email"
+                placeholder={t('email')}
               />
               {errors.email && (
                 <p className="mt-1 text-xs text-red-600 dark:text-red-500">{errors.email.message}</p>
               )}
             </div>
             <div>
-              <label htmlFor="password-for-login" className="sr-only">Kata Sandi</label>
+              <label htmlFor="password-for-login" className="sr-only">{t('password')}</label>
               <input
                 id="password-for-login"
                 type="password"
                 autoComplete="current-password"
                 {...register('password')}
                 className={`appearance-none rounded-none relative block w-full px-3 py-2 border placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white ${errors.password ? 'border-red-500' : 'border-gray-300'}`}
-                placeholder="Kata Sandi"
+                placeholder={t('password')}
               />
               {errors.password && (
                 <p className="mt-1 text-xs text-red-600 dark:text-red-500">{errors.password.message}</p>
@@ -76,7 +78,7 @@ const LoginPage: React.FC<LoginPageProps> = ({ onLogin, loginError }) => {
           </div>
           <div>
             <Button type="submit" className="w-full" disabled={!isValid}>
-              Login
+              {t('login')}
             </Button>
           </div>
         </form>

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -1,12 +1,14 @@
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 const Footer: React.FC = () => {
+  const { t } = useTranslation();
   const currentYear = new Date().getFullYear();
 
   return (
     <footer className="w-full bg-white dark:bg-gray-800 border-t dark:border-gray-700 p-4 text-center text-sm text-gray-500 dark:text-gray-400 flex-shrink-0">
-      &copy; {currentYear} HRIS UNUGHA | Hubungi Dukungan: Bidang Sumber Daya Manusia UNUGHA Cilacap
+      {t('footerText', { year: currentYear })}
     </footer>
   );
 };

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -3,8 +3,12 @@ import React, { useState, useEffect, useRef } from 'react';
 import UserProfileModal from '../user/UserProfileModal';
 import { useAuth } from '../../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useLanguage } from '../../context/LanguageContext';
 
 const Header: React.FC = () => {
+  const { t } = useTranslation();
+  const { language, setLanguage } = useLanguage();
   const { user, logout } = useAuth();
   const navigate = useNavigate();
   if (!user) return null;
@@ -30,19 +34,27 @@ const Header: React.FC = () => {
     <header className="flex items-center justify-between h-20 px-6 bg-white dark:bg-gray-800 border-b dark:border-gray-700 flex-shrink-0">
       <div className="flex items-center">
         {/* Can be used for breadcrumbs or page title */}
-        <h2 className="text-2xl font-semibold text-gray-800 dark:text-white">Dashboard</h2>
+        <h2 className="text-2xl font-semibold text-gray-800 dark:text-white">{t('dashboard')}</h2>
       </div>
       <div className="flex items-center space-x-6">
         <div className="relative">
           <input
             type="text"
-            placeholder="Search..."
+            placeholder={t('search')}
             className="pl-10 pr-4 py-2 w-full max-w-xs bg-gray-100 dark:bg-gray-700 border border-transparent rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
           <span className="absolute inset-y-0 left-0 flex items-center pl-3">
             <i className="fas fa-search text-gray-400"></i>
           </span>
         </div>
+        <select
+          value={language}
+          onChange={(e) => setLanguage(e.target.value)}
+          className="bg-gray-100 dark:bg-gray-700 border border-transparent rounded-lg px-3 py-2 text-sm text-gray-800 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          <option value="en">{t('english')}</option>
+          <option value="id">{t('indonesian')}</option>
+        </select>
         <button className="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">
           <i className="fas fa-bell fa-lg"></i>
         </button>
@@ -65,14 +77,14 @@ const Header: React.FC = () => {
                         }}
                         className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700"
                     >
-                        <i className="fas fa-user-edit w-5 mr-2"></i>Edit Profil
+                        <i className="fas fa-user-edit w-5 mr-2"></i>{t('editProfile')}
                     </a>
                     <a
                         href="#"
                         onClick={(e) => { e.preventDefault(); logout(); navigate('/'); }}
                         className="block px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700"
                     >
-                       <i className="fas fa-sign-out-alt w-5 mr-2"></i>Logout
+                       <i className="fas fa-sign-out-alt w-5 mr-2"></i>{t('logout')}
                     </a>
                 </div>
             )}

--- a/context/LanguageContext.tsx
+++ b/context/LanguageContext.tsx
@@ -1,0 +1,33 @@
+import React, { createContext, useContext, useState } from 'react';
+import i18n from 'i18next';
+
+type LanguageContextType = {
+  language: string;
+  setLanguage: (lng: string) => void;
+};
+
+const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
+
+export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [language, setLanguageState] = useState(i18n.language || 'en');
+
+  const setLanguage = (lng: string) => {
+    i18n.changeLanguage(lng);
+    setLanguageState(lng);
+  };
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export const useLanguage = () => {
+  const context = useContext(LanguageContext);
+  if (!context) {
+    throw new Error('useLanguage must be used within a LanguageProvider');
+  }
+  return context;
+};
+

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,14 @@
+{
+  "dashboard": "Dashboard",
+  "search": "Search...",
+  "editProfile": "Edit Profile",
+  "logout": "Logout",
+  "language": "Language",
+  "english": "English",
+  "indonesian": "Indonesian",
+  "welcomeBack": "Welcome Back",
+  "email": "Email Address",
+  "password": "Password",
+  "login": "Login",
+  "footerText": "© {{year}} HRIS UNUGHA | Contact Support: Human Resources Department UNUGHA Cilacap"
+}

--- a/i18n/id.json
+++ b/i18n/id.json
@@ -1,0 +1,14 @@
+{
+  "dashboard": "Dasbor",
+  "search": "Cari...",
+  "editProfile": "Edit Profil",
+  "logout": "Keluar",
+  "language": "Bahasa",
+  "english": "Inggris",
+  "indonesian": "Indonesia",
+  "welcomeBack": "Selamat Datang Kembali",
+  "email": "Alamat Email",
+  "password": "Kata Sandi",
+  "login": "Masuk",
+  "footerText": "© {{year}} HRIS UNUGHA | Hubungi Dukungan: Bidang Sumber Daya Manusia UNUGHA Cilacap"
+}

--- a/index.tsx
+++ b/index.tsx
@@ -4,6 +4,21 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import { AuthProvider } from './context/AuthContext';
 import ErrorBoundary from './components/shared/ErrorBoundary';
+import { LanguageProvider } from './context/LanguageContext';
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import en from './i18n/en.json';
+import id from './i18n/id.json';
+
+i18n.use(initReactI18next).init({
+  resources: {
+    en: { translation: en },
+    id: { translation: id },
+  },
+  lng: 'en',
+  fallbackLng: 'en',
+  interpolation: { escapeValue: false },
+});
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -15,9 +30,11 @@ root.render(
   <React.StrictMode>
     <ErrorBoundary>
       <BrowserRouter>
-        <AuthProvider>
-          <App />
-        </AuthProvider>
+        <LanguageProvider>
+          <AuthProvider>
+            <App />
+          </AuthProvider>
+        </LanguageProvider>
       </BrowserRouter>
     </ErrorBoundary>
   </React.StrictMode>,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "react-hook-form": "^7.51.5",
     "zod": "^3.24.1",
     "@hookform/resolvers": "^3.6.0",
-    "xlsx": "^0.19.3"
+    "xlsx": "^0.19.3",
+    "react-i18next": "^15.1.4",
+    "i18next": "^23.10.1"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",


### PR DESCRIPTION
## Summary
- add react-i18next translations for English and Indonesian
- wire up i18n initialization and language context
- replace hardcoded strings and add language selector in header

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: Rollup failed to resolve import "i18next")*


------
https://chatgpt.com/codex/tasks/task_e_68b47fe9ae0c832b9af9824d15e9f249